### PR TITLE
Replace deprecated use of util method to support Mojolicious 7.78

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for Perl module MojoX::Plugin::PODRenderer
 
 {{$NEXT}}
 
+0.31  2018-05-16
+  - Replace deprecated methods to support Mojolicious 7.78
+
 0.30  2014-07-31
   - harmonise to CHGOVUK standard
 

--- a/lib/MojoX/Plugin/PODRenderer.pm
+++ b/lib/MojoX/Plugin/PODRenderer.pm
@@ -5,14 +5,15 @@ use Mojo::Base 'Mojolicious::Plugin';
 use Mojo::Asset::File;
 use Mojo::ByteStream 'b';
 use Mojo::DOM;
-use Mojo::Util qw(slurp url_escape class_to_path xml_escape);
+use Mojo::Util qw(url_escape class_to_path xml_escape);
+use Mojo::File 'path';
 use Pod::Simple::HTML;
 use Pod::Simple::Search;
 use boolean;
 use Class::MOP;
 use File::Find;
 
-our $VERSION = '0.30';
+our $VERSION = '0.31';
 
 # Paths to search
 my @PATHS = map { $_, "$_/pods" } @INC;
@@ -172,7 +173,7 @@ sub _perldoc {
         return _generateIndex($self);
     }
     else {
-        my $slurped = slurp $path;
+        my $slurped = path($path)->slurp;
         $html = $is_perl_source ? "<pre>".xml_escape($slurped)."</pre>" : _pod_to_html($slurped);
 
         # Ensure % gets escaped before going into the template


### PR DESCRIPTION
The `Mojolicious` framework `slurp` method has been deprecated and since removed (see https://github.com/kraih/mojo/blob/master/Changes#L291).  This change replaces the deprecated method call with `Mojo::File::slurp`.